### PR TITLE
fix pip: command not found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 sudo apt install bpftrace
+sudo apt-get install python3-pip
 pip install -r requirements.txt


### PR DESCRIPTION
I fixed pip: command not found(https://github.com/eunomia-bpf/GPTtrace/issues/1)